### PR TITLE
Fix swagger and support direct backend env

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,9 @@ app = FastAPI(
     title="Image Converter API",
     description="이미지 형식 변환, 크기 조정, 품질 최적화 API",
     version="0.1.0",
+    openapi_url="/api/openapi.json",
+    docs_url="/api/docs",
+    redoc_url="/api/redoc",
 )
 
 # CORS 설정 - 개발 환경용

--- a/frontend/src/services/imageService.ts
+++ b/frontend/src/services/imageService.ts
@@ -1,9 +1,14 @@
 import axios from 'axios';
 import { ConversionOptions } from '../stores/imageStore';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
-// REACT_APP_API_URL should be set to the proxy prefix ("/api").
-// Endpoints below omit this prefix to avoid `/api/api` duplication.
+const API_BASE_URL =
+  process.env.REACT_APP_BACKEND_ENDPOINT ||
+  process.env.REACT_APP_API_URL ||
+  '/api';
+// `REACT_APP_BACKEND_ENDPOINT` can point directly to the backend service
+// (e.g. "http://image-converter-backend:8000"). Otherwise `REACT_APP_API_URL`
+// should contain the proxy prefix ("/api"). Endpoints below omit this prefix to
+// avoid `/api/api` duplication.
 
 // 테스트 환경에서 사용할 수 있도록 export
 export const apiClient = axios.create({

--- a/infra/helm-chart/kkamji_values.yaml
+++ b/infra/helm-chart/kkamji_values.yaml
@@ -1,7 +1,7 @@
 global:
   imageRegistry: harbor.kkamji.net
   imagePullSecrets:
-  - name: harbor-credentials
+    - name: harbor-credentials
 
 fullnameOverride: image-converter
 
@@ -10,14 +10,14 @@ backend:
     repository: image-converter/backend
     tag: "latest"
     pullPolicy: Always
-  
+
   replicaCount: 1
-  
+
   service:
     type: ClusterIP
     port: 8000
     targetPort: 8000
-  
+
   resources:
     limits:
       cpu: 500m
@@ -25,11 +25,11 @@ backend:
     requests:
       cpu: 250m
       memory: 256Mi
-  
+
   env:
     - name: PYTHONPATH
       value: "/app"
-  
+
   healthcheck:
     enabled: true
     path: /health
@@ -41,14 +41,14 @@ frontend:
     repository: image-converter/frontend
     tag: "latest"
     pullPolicy: Always
-  
+
   replicaCount: 1
-  
+
   service:
     type: ClusterIP
     port: 80
     targetPort: 80
-  
+
   resources:
     limits:
       cpu: 200m
@@ -56,10 +56,12 @@ frontend:
     requests:
       cpu: 100m
       memory: 128Mi
-  
+
   env:
     - name: REACT_APP_API_URL
       value: "/api"
+    - name: REACT_APP_BACKEND_ENDPOINT
+      value: "http://image-converter-backend:8000"
     - name: BACKEND_ENDPOINT
       value: "http://image-converter-backend:8000"
 
@@ -91,7 +93,7 @@ autoscaling:
     maxReplicas: 3
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80
-  
+
   frontend:
     enabled: true
     minReplicas: 1

--- a/infra/helm-chart/values.yaml
+++ b/infra/helm-chart/values.yaml
@@ -8,14 +8,14 @@ backend:
     repository: image-converter/backend
     tag: "v1.0.0"
     pullPolicy: IfNotPresent
-  
+
   replicaCount: 2
-  
+
   service:
     type: ClusterIP
     port: 8000
     targetPort: 8000
-  
+
   resources:
     limits:
       cpu: 500m
@@ -23,11 +23,11 @@ backend:
     requests:
       cpu: 250m
       memory: 256Mi
-  
+
   env:
     - name: PYTHONPATH
       value: "/app"
-  
+
   healthcheck:
     enabled: true
     path: /health
@@ -39,14 +39,14 @@ frontend:
     repository: image-converter/frontend
     tag: "v1.0.0"
     pullPolicy: IfNotPresent
-  
+
   replicaCount: 2
-  
+
   service:
     type: ClusterIP
     port: 80
     targetPort: 80
-  
+
   resources:
     limits:
       cpu: 200m
@@ -54,10 +54,12 @@ frontend:
     requests:
       cpu: 100m
       memory: 128Mi
-  
+
   env:
     - name: REACT_APP_API_URL
       value: "/api"
+    - name: REACT_APP_BACKEND_ENDPOINT
+      value: "http://image-converter-backend:8000"
     - name: BACKEND_ENDPOINT
       value: "http://image-converter-backend:8000"
 
@@ -87,7 +89,7 @@ autoscaling:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80
-  
+
   frontend:
     enabled: true
     minReplicas: 2


### PR DESCRIPTION
## Summary
- expose FastAPI docs under `/api` path
- allow frontend to call backend directly using `REACT_APP_BACKEND_ENDPOINT`
- add new env variable to Helm values

## Testing
- `./run_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850f201d32c83208fb43cd75cd75663