### PR TITLE
Extend API timeout to 90s

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -207,7 +207,7 @@ curl -X POST "http://localhost:8000/api/v1/convert" \
 - **최대 파일 크기**: 50MB
 - **지원 형식**: WebP, JPEG, JPG, PNG, BMP, TIFF (입력), WebP, JPEG, JPG, PNG (출력)
 - **동시 요청**: 제한 없음 (현재 버전)
-- **요청 타임아웃**: 30초
+- **요청 타임아웃**: 90초 (1분 30초)
 
 ---
 

--- a/frontend/src/services/imageService.ts
+++ b/frontend/src/services/imageService.ts
@@ -13,7 +13,7 @@ const API_BASE_URL =
 // 테스트 환경에서 사용할 수 있도록 export
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 30000, // 30초 타임아웃
+  timeout: 90000, // 90초 타임아웃
 });
 
 export const convertImage = async (


### PR DESCRIPTION
## Summary
- increase frontend API client timeout to 90s
- document new timeout in API spec

## Testing
- `./run_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851298124748320aa9bb4cade9c9eed