### PR TITLE
feat: display converted image size

### DIFF
--- a/backend/app/services/image_converter.py
+++ b/backend/app/services/image_converter.py
@@ -1,6 +1,8 @@
 """
 이미지 변환 서비스
 PIL을 사용한 이미지 형식 변환, 크기 조정, 품질 최적화
+
+TL;DR: Provides high-quality resizing and format conversion.
 """
 
 import asyncio
@@ -99,7 +101,10 @@ class ImageConverter:
             (original_width, original_height),
             (new_width, new_height),
         )
-        return image.resize((new_width, new_height), Image.Resampling.LANCZOS)
+        # ImageOps.contain provides higher quality for large reductions
+        return ImageOps.contain(
+            image, (new_width, new_height), method=Image.Resampling.LANCZOS
+        )
 
     def _convert_format(self, image: Image.Image, request: ConversionRequest) -> bytes:
         """이미지 형식 변환"""
@@ -127,6 +132,7 @@ class ImageConverter:
                 {
                     "quality": request.quality,
                     "optimize": True,
+                    "subsampling": 0,
                 }
             )
         elif request.target_format == "webp":

--- a/frontend/src/components/ConversionResult.tsx
+++ b/frontend/src/components/ConversionResult.tsx
@@ -4,8 +4,13 @@ import { useImageStore } from '../stores/imageStore';
 import './ConversionResult.css';
 
 export const ConversionResult: React.FC = () => {
-  const { convertedImageUrl, selectedFile, conversionOptions, reset } =
-    useImageStore();
+  const {
+    convertedImageUrl,
+    selectedFile,
+    convertedMetadata,
+    conversionOptions,
+    reset,
+  } = useImageStore();
 
   const handleDownload = () => {
     if (!convertedImageUrl || !selectedFile) return;
@@ -58,6 +63,15 @@ export const ConversionResult: React.FC = () => {
             {conversionOptions.targetFormat.toUpperCase()}
           </span>
         </div>
+        {convertedMetadata && (
+          <div className="info-item">
+            <span className="info-label">결과 크기:</span>
+            <span className="info-value">
+              {convertedMetadata.width} × {convertedMetadata.height} /{' '}
+              {(convertedMetadata.size / 1024).toFixed(1)}KB
+            </span>
+          </div>
+        )}
         {conversionOptions.quality && (
           <div className="info-item">
             <span className="info-label">품질:</span>

--- a/frontend/src/components/ImageConverter.tsx
+++ b/frontend/src/components/ImageConverter.tsx
@@ -16,6 +16,7 @@ export const ImageConverter: React.FC = () => {
     error,
     setProgress,
     setConvertedImageUrl,
+    setConvertedMetadata,
     setError,
   } = useImageStore();
 
@@ -59,8 +60,13 @@ export const ImageConverter: React.FC = () => {
       setProgress({ progress: 90, message: '변환 완료 처리 중...' });
 
       // Blob URL 생성
-      const url = URL.createObjectURL(result);
+      const url = URL.createObjectURL(result.blob);
       setConvertedImageUrl(url);
+      setConvertedMetadata({
+        width: result.width,
+        height: result.height,
+        size: result.size,
+      });
 
       setProgress({
         isConverting: false,

--- a/frontend/src/components/__tests__/ConversionResult.test.tsx
+++ b/frontend/src/components/__tests__/ConversionResult.test.tsx
@@ -6,6 +6,7 @@ import { ConversionResult } from '../ConversionResult';
 jest.mock('../../stores/imageStore', () => ({
   useImageStore: () => ({
     convertedImageUrl: 'mock-url',
+    convertedMetadata: { width: 100, height: 50, size: 2048 },
     selectedFile: new File(['test'], 'test.png', { type: 'image/png' }),
     conversionOptions: {
       targetFormat: 'webp',
@@ -37,5 +38,12 @@ describe('ConversionResult', () => {
 
     const newButton = screen.getByText(/다시 변환/i);
     expect(newButton).toBeInTheDocument();
+  });
+
+  test('shows converted image size', () => {
+    render(<ConversionResult />);
+
+    const info = screen.getByText(/결과 크기/i);
+    expect(info).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/ImageConverter.test.tsx
+++ b/frontend/src/components/__tests__/ImageConverter.test.tsx
@@ -22,6 +22,7 @@ Object.defineProperty(global.URL, 'revokeObjectURL', {
 const mockSetProgress = jest.fn();
 const mockSetConvertedImageUrl = jest.fn();
 const mockSetError = jest.fn();
+const mockSetConvertedMetadata = jest.fn();
 
 jest.mock('../../stores/imageStore', () => ({
   useImageStore: () => ({
@@ -42,6 +43,7 @@ jest.mock('../../stores/imageStore', () => ({
     error: null,
     setProgress: mockSetProgress,
     setConvertedImageUrl: mockSetConvertedImageUrl,
+    setConvertedMetadata: mockSetConvertedMetadata,
     setError: mockSetError,
   }),
 }));
@@ -62,7 +64,12 @@ describe('ImageConverter', () => {
 
   test('handles successful conversion', async () => {
     const mockBlob = new Blob(['converted-image'], { type: 'image/webp' });
-    mockConvertImage.mockResolvedValue(mockBlob);
+    mockConvertImage.mockResolvedValue({
+      blob: mockBlob,
+      size: mockBlob.size,
+      width: 100,
+      height: 50,
+    });
 
     render(<ImageConverter />);
 
@@ -99,6 +106,14 @@ describe('ImageConverter', () => {
     // URL.createObjectURL이 호출되었는지 확인
     await waitFor(() => {
       expect(global.URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+    });
+
+    await waitFor(() => {
+      expect(mockSetConvertedMetadata).toHaveBeenCalledWith({
+        width: 100,
+        height: 50,
+        size: mockBlob.size,
+      });
     });
 
     // 최종 상태 확인 - 실제로 호출되는 값으로 수정

--- a/frontend/src/services/__tests__/imageService.test.ts
+++ b/frontend/src/services/__tests__/imageService.test.ts
@@ -21,7 +21,12 @@ describe('imageService', () => {
   describe('convertImage', () => {
     test('successful conversion', async () => {
       const mockBlob = new Blob(['test'], { type: 'image/webp' });
-      mockConvertImage.mockResolvedValue(mockBlob);
+      mockConvertImage.mockResolvedValue({
+        blob: mockBlob,
+        size: mockBlob.size,
+        width: 50,
+        height: 50,
+      });
 
       const file = new File(['test'], 'test.png', { type: 'image/png' });
       const options = {
@@ -35,7 +40,12 @@ describe('imageService', () => {
       const result = await convertImage(file, options);
 
       expect(mockConvertImage).toHaveBeenCalledWith(file, options);
-      expect(result).toEqual(mockBlob);
+      expect(result).toEqual({
+        blob: mockBlob,
+        size: mockBlob.size,
+        width: 50,
+        height: 50,
+      });
     });
 
     test('handles conversion error', async () => {

--- a/frontend/src/stores/imageStore.ts
+++ b/frontend/src/stores/imageStore.ts
@@ -19,12 +19,16 @@ interface ImageState {
   conversionOptions: ConversionOptions;
   progress: ConversionProgress;
   convertedImageUrl: string | null;
+  convertedMetadata: { width: number; height: number; size: number } | null;
   error: string | null;
 
   setSelectedFile: (file: File | null) => void;
   setConversionOptions: (options: Partial<ConversionOptions>) => void;
   setProgress: (progress: Partial<ConversionProgress>) => void;
   setConvertedImageUrl: (url: string | null) => void;
+  setConvertedMetadata: (
+    metadata: { width: number; height: number; size: number } | null
+  ) => void;
   setError: (error: string | null) => void;
   reset: () => void;
 }
@@ -41,6 +45,7 @@ const initialState = {
     message: '',
   },
   convertedImageUrl: null,
+  convertedMetadata: null,
   error: null,
 };
 
@@ -60,6 +65,7 @@ export const useImageStore = create<ImageState>((set) => ({
     })),
 
   setConvertedImageUrl: (url) => set({ convertedImageUrl: url }),
+  setConvertedMetadata: (metadata) => set({ convertedMetadata: metadata }),
 
   setError: (error) => set({ error }),
 


### PR DESCRIPTION
## Summary
- improve resizing with ImageOps.contain and JPEG subsampling off
- return width/height/size in convertImage service
- show converted image dimensions and size in UI
- update unit tests for metadata handling

## Testing
- `./run_and_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68517dfd889483208564e2663114bdfd